### PR TITLE
Fix broken mappings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx2G
 # Fabric Properties
 	# check these on https://fabricmc.net/use
 	minecraft_version = 1.13.2
-	yarn_mappings = 1.13.2+build.202112231748
+	yarn_mappings = 1.13.2+build.202201221458
 	loader_version = 0.12.12
 
 # Mod Properties


### PR DESCRIPTION
Makes it so that the examplemod can launch without needing to upgrade mappings on 1.13.2.